### PR TITLE
Use Gradle Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,60 @@
-/build/
-/.groovy/
-/.settings/
-/bin/
-/.gradle/
-.project
-.DS_Store
-.classpath
+# Created by https://www.gitignore.io/api/intellij,gradle
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ There are three tasks included in the plugin:
  - Create a new task that populates your DB, executing the operation `CLEAN_INSERT` and using the file `$rootFir/db/sample-data.xml`:
 
   ```groovy
-  task populateTestDb(type: com.ferigma.gradle.dbunit.tasks.OperationTask) {
+  dbunit {
      username = "sa"
      password = "sa"
      url = "jdbc:h2:/tmp/h2_test"
      driver = "org.h2.Driver"
      dataTypeFactoryName = "org.dbunit.ext.h2.H2DataTypeFactory"
+  }
+
+  task populateTestDb(type: com.ferigma.gradle.dbunit.tasks.OperationTask) {
      sources = [
         new com.ferigma.gradle.dbunit.tasks.vo.OperationSource(
         transaction: true, type: "CLEAN_INSERT", format: "xml",

--- a/src/main/groovy/com/ferigma/gradle/dbunit/DbunitGradlePlugin.groovy
+++ b/src/main/groovy/com/ferigma/gradle/dbunit/DbunitGradlePlugin.groovy
@@ -1,5 +1,7 @@
 package com.ferigma.gradle.dbunit
 
+import com.ferigma.gradle.dbunit.tasks.AbstractDbunitTask
+import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -22,6 +24,7 @@ import com.ferigma.gradle.dbunit.tasks.OperationTask
  * </ul>
  *
  * @author Fernando Iglesias Martinez
+ * @author Sion Williams
  * @see http://dbunit.sourceforge.net
  * @see http://mojo.codehaus.org/dbunit-maven-plugin
  * @see http://github.com/ferigma/dbunit-gradle-plugin
@@ -40,13 +43,41 @@ class DbunitGradlePlugin implements Plugin<Project> {
       // Project Description
       target.description = "DbUnit Gradle Plugin"
 
-      registerExtensions(target)
+      registerDbunitExtensions(target)
+      applyConventionMappingToDbunitTasks(target)
       registerTasks(target)
 
    }
 
-   private DbunitPluginExtension registerExtensions(Project target) {
+   private DbunitPluginExtension registerDbunitExtensions(Project target) {
       target.extensions.create('dbunit', DbunitPluginExtension)
+   }
+
+   /**
+    * assign the values from the extension object properties to the task properties with a closure.
+    * This means the value of the properties are lazy set: only when the task gets executed the task
+    * property values are calculated.
+    * @param target
+     */
+   private void applyConventionMappingToDbunitTasks(Project target) {
+      def dbunitExtension = target.extensions.findByName('dbunit')
+
+      target.tasks.withType(AbstractDbunitTask) {
+         conventionMapping.driver = { dbunitExtension.driver }
+         conventionMapping.username = { dbunitExtension.username }
+         conventionMapping.password = { dbunitExtension.password }
+         conventionMapping.url = { dbunitExtension.url }
+         conventionMapping.schema = { dbunitExtension.schema }
+         conventionMapping.dataTypeFactoryName = { dbunitExtension.dataTypeFactoryName }
+         conventionMapping.supportBatchStatement = { dbunitExtension.supportBatchStatement }
+         conventionMapping.useQualifiedTableNames = { dbunitExtension.useQualifiedTableNames }
+         conventionMapping.datatypeWarning = { dbunitExtension.datatypeWarning }
+         conventionMapping.escapePattern = { dbunitExtension.escapePattern }
+         conventionMapping.skipOracleRecycleBinTables = { dbunitExtension.skipOracleRecycleBinTables }
+         conventionMapping.skip = { dbunitExtension.skip }
+         conventionMapping.metadataHandlerName = { dbunitExtension.metadataHandlerName }
+         conventionMapping.caseSensitiveTableNames = { dbunitExtension.caseSensitiveTableNames }
+      }
    }
 
    private void registerTasks(Project target) {

--- a/src/main/groovy/com/ferigma/gradle/dbunit/DbunitGradlePlugin.groovy
+++ b/src/main/groovy/com/ferigma/gradle/dbunit/DbunitGradlePlugin.groovy
@@ -40,10 +40,18 @@ class DbunitGradlePlugin implements Plugin<Project> {
       // Project Description
       target.description = "DbUnit Gradle Plugin"
 
-      // Tasks
+      registerExtensions(target)
+      registerTasks(target)
+
+   }
+
+   private DbunitPluginExtension registerExtensions(Project target) {
+      target.extensions.create('dbunit', DbunitPluginExtension)
+   }
+
+   private void registerTasks(Project target) {
       target.task('compare', type: CompareTask)
       target.task('export', type: ExportTask)
       target.task('operation', type: OperationTask)
-
    }
 }

--- a/src/main/groovy/com/ferigma/gradle/dbunit/DbunitPluginExtension.groovy
+++ b/src/main/groovy/com/ferigma/gradle/dbunit/DbunitPluginExtension.groovy
@@ -1,0 +1,68 @@
+package com.ferigma.gradle.dbunit
+
+/**
+ * This is an extension object for grouping properties together. This is used to add a configuration
+ * block to the Gradle project.
+ *
+ * @author Sion Williams
+ */
+class DbunitPluginExtension {
+    static final String DEFAULT_DATA_TYPE_FACTORY_NAME =
+            "org.dbunit.dataset.datatype.DefaultDataTypeFactory"
+    static final String DEFAULT_METADA_HANDLER_NAME =
+            "org.dbunit.database.DefaultMetadataHandler"
+
+    /** The driver. */
+    String driver
+
+    /** The username. */
+    String username
+
+    /** The password. */
+    String password
+
+    /** The url. */
+    String url
+
+    /** The schema name that tables can be found under. */
+    String schema
+
+    /**
+     * Set the DataType factory to add support for non-standard database vendor
+     * data types.
+     */
+    String dataTypeFactoryName = DEFAULT_DATA_TYPE_FACTORY_NAME
+
+    /** Enable or disable usage of JDBC batched statement by DbUnit */
+    boolean supportBatchStatement = false
+
+    /**
+     * Enable or disable multiple schemas support by prefixing table names with
+     * the schema name.
+     */
+    boolean useQualifiedTableNames = false
+
+    /**
+     * Enable or disable the warning message displayed when DbUnit encounter an
+     * unsupported data type.
+     */
+    boolean datatypeWarning = false
+
+    /** escapePattern */
+    String escapePattern
+
+    /** skipOracleRecycleBinTables */
+    boolean skipOracleRecycleBinTables = false
+
+    /**
+     * Skip the execution when true, very handy when using together with
+     * maven.test.skip.
+     */
+    boolean skip = false
+
+    /** Class name of metadata handler. */
+    String metadataHandlerName = DEFAULT_METADA_HANDLER_NAME
+
+    /** Be case sensitive when handling tables. */
+    boolean caseSensitiveTableNames = false
+}

--- a/src/main/groovy/com/ferigma/gradle/dbunit/tasks/AbstractDbunitTask.groovy
+++ b/src/main/groovy/com/ferigma/gradle/dbunit/tasks/AbstractDbunitTask.groovy
@@ -20,13 +20,9 @@ import com.ferigma.gradle.dbunit.DbunitGradlePlugin
  * Base class for all DBUnit plugin tasks.
  *
  * @author Fernando Iglesias Martinez
+ * @author Sion Williams
  */
 abstract class AbstractDbunitTask extends DefaultTask {
-
-   static final String DEFAULT_DATA_TYPE_FACTORY_NAME =
-   "org.dbunit.dataset.datatype.DefaultDataTypeFactory"
-   static final String DEFAULT_METADA_HANDLER_NAME =
-   "org.dbunit.database.DefaultMetadataHandler"
 
    static final String PROPERTY_USER = "user"
    static final String PROPERTY_PASSWORD = "password"
@@ -58,12 +54,12 @@ abstract class AbstractDbunitTask extends DefaultTask {
     */
    @Input
    @Optional
-   String dataTypeFactoryName = DEFAULT_DATA_TYPE_FACTORY_NAME
+   String dataTypeFactoryName
 
    /** Enable or disable usage of JDBC batched statement by DbUnit */
    @Input
    @Optional
-   boolean supportBatchStatement = false
+   boolean supportBatchStatement
 
    /**
     * Enable or disable multiple schemas support by prefixing table names with
@@ -71,7 +67,7 @@ abstract class AbstractDbunitTask extends DefaultTask {
     */
    @Input
    @Optional
-   boolean useQualifiedTableNames = false
+   boolean useQualifiedTableNames
 
    /**
     * Enable or disable the warning message displayed when DbUnit encounter an
@@ -79,7 +75,7 @@ abstract class AbstractDbunitTask extends DefaultTask {
     */
    @Input
    @Optional
-   boolean datatypeWarning = false
+   boolean datatypeWarning
 
    /** escapePattern */
    @Input
@@ -89,7 +85,7 @@ abstract class AbstractDbunitTask extends DefaultTask {
    /** skipOracleRecycleBinTables */
    @Input
    @Optional
-   boolean skipOracleRecycleBinTables = false
+   boolean skipOracleRecycleBinTables
 
    /**
     * Skip the execution when true, very handy when using together with
@@ -97,17 +93,17 @@ abstract class AbstractDbunitTask extends DefaultTask {
     */
    @Input
    @Optional
-   boolean skip = false
+   boolean skip
 
    /** Class name of metadata handler. */
    @Input
    @Optional
-   String metadataHandlerName = DEFAULT_METADA_HANDLER_NAME
+   String metadataHandlerName
 
    /** Be case sensitive when handling tables. */
    @Input
    @Optional
-   boolean caseSensitiveTableNames = false
+   boolean caseSensitiveTableNames
 
    IDatabaseConnection connection
 
@@ -125,33 +121,33 @@ abstract class AbstractDbunitTask extends DefaultTask {
 
          // Connection properties
          Properties properties = new Properties()
-         properties.put(PROPERTY_USER, username)
-         properties.put(PROPERTY_PASSWORD, password)
+         properties.put(PROPERTY_USER, getUsername())
+         properties.put(PROPERTY_PASSWORD, getPassword())
 
          // Database driver
-         Driver driver = (Driver) Class.forName(driver).newInstance()
-         Connection driverConnection = driver.connect(url, properties)
+         Driver driver = (Driver) Class.forName(getDriver()).newInstance()
+         Connection driverConnection = driver.connect(getUrl(), properties)
          driverConnection.setAutoCommit(true)
 
          // Database connection
-         connection = new DatabaseConnection(driverConnection, schema)
+         connection = new DatabaseConnection(driverConnection, getSchema())
          DatabaseConfig config = connection.getConfig()
 
          // Connection configuration
-         config.setProperty(DatabaseConfig.FEATURE_BATCHED_STATEMENTS, supportBatchStatement)
-         config.setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, useQualifiedTableNames)
-         config.setProperty(DatabaseConfig.FEATURE_DATATYPE_WARNING, datatypeWarning)
-         config.setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, skipOracleRecycleBinTables)
-         config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, caseSensitiveTableNames)
-         config.setProperty(DatabaseConfig.PROPERTY_ESCAPE_PATTERN, escapePattern)
+         config.setProperty(DatabaseConfig.FEATURE_BATCHED_STATEMENTS, getSupportBatchStatement())
+         config.setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, getUseQualifiedTableNames())
+         config.setProperty(DatabaseConfig.FEATURE_DATATYPE_WARNING, getDatatypeWarning())
+         config.setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, getSkipOracleRecycleBinTables())
+         config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, getCaseSensitiveTableNames())
+         config.setProperty(DatabaseConfig.PROPERTY_ESCAPE_PATTERN, getEscapePattern())
          config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, new ForwardOnlyResultSetTableFactory())
 
          // Setup data type factory
-         IDataTypeFactory dataTypeFactory = (IDataTypeFactory) Class.forName(dataTypeFactoryName).newInstance()
+         IDataTypeFactory dataTypeFactory = (IDataTypeFactory) Class.forName(getDataTypeFactoryName()).newInstance()
          config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, dataTypeFactory)
 
          // Setup metadata handler
-         IMetadataHandler metadataHandler = (IMetadataHandler) Class.forName(metadataHandlerName).newInstance()
+         IMetadataHandler metadataHandler = (IMetadataHandler) Class.forName(getMetadataHandlerName()).newInstance()
          config.setProperty(DatabaseConfig.PROPERTY_METADATA_HANDLER, metadataHandler)
 
          // Do concrete task

--- a/src/test/groovy/com/ferigma/gradle/dbunit/DbunitGradlePluginTest.groovy
+++ b/src/test/groovy/com/ferigma/gradle/dbunit/DbunitGradlePluginTest.groovy
@@ -66,13 +66,16 @@ class DbunitGradlePluginTest {
       project = ProjectBuilder.builder().build()
       project.apply plugin: 'dbunit'
 
-      // Operation Task (CLEAN_INSERT)
-      operationTask = project.tasks.operation {
+      project.dbunit {
          username = DB_USERNAME
          password = DB_PASSWORD
          url = DB_URL
          driver = DB_DRIVER
          dataTypeFactoryName = DATA_TYPE_FACTORY
+      }
+
+      // Operation Task (CLEAN_INSERT)
+      operationTask = project.tasks.operation {
          sources = [
             new OperationSource(transaction: true, type: "CLEAN_INSERT",
             format: "xml", file: "build/resources/test/sample-data.xml")
@@ -81,11 +84,6 @@ class DbunitGradlePluginTest {
 
       // CompareTask
       compareTask = project.tasks.compare {
-         username = DB_USERNAME
-         password = DB_PASSWORD
-         url = DB_URL
-         driver = DB_DRIVER
-         dataTypeFactoryName = DATA_TYPE_FACTORY
          sources = [
             new CompareSource(format: "xml",
             file: "build/resources/test/sample-data.xml")
@@ -94,11 +92,6 @@ class DbunitGradlePluginTest {
 
       // ExportTask
       exportTask = project.tasks.export {
-         username = DB_USERNAME
-         password = DB_PASSWORD
-         url = DB_URL
-         driver = DB_DRIVER
-         dataTypeFactoryName = DATA_TYPE_FACTORY
          sources = [
             new ExportSource(format: "xml",
             destination: "build/test-results/result-data.xml")

--- a/src/test/groovy/com/ferigma/gradle/dbunit/DbunitGradlePluginTest.groovy
+++ b/src/test/groovy/com/ferigma/gradle/dbunit/DbunitGradlePluginTest.groovy
@@ -129,4 +129,9 @@ class DbunitGradlePluginTest {
       operationTask.execute()
       exportTask.execute()
    }
+
+   @Test
+   void pluginAddsExtension() {
+      assert project.extensions.findByName('dbunit')
+   }
 }


### PR DESCRIPTION
This is a pr for the enhancement I raised of the same name. Whilst the change is fairly small, it adds a lot of new features to the plugin. You can now group common properties in a configuration block (as described in the issue), whilst also maintaining the ability to set properties inside the task (as before).

As these are loaded in a lazy way (when they are required), it means you can have more than one task of the same type, but with different configurations.
